### PR TITLE
Add binary exponential back-off algorithm

### DIFF
--- a/retry
+++ b/retry
@@ -6,7 +6,8 @@ options:
     -h,--help               Show this help
     -r,--retries=RETRIES    How many retries to do on command failure after the
                             initial try. Defaults to 3.
-    -s,--sleep=SLEEP        How many seconds to sleep between retries
+    -s,--sleep=SLEEP        How many seconds to sleep between retries. Defaults
+                            to 3 seconds.
     "
     exit "$1"
 }

--- a/retry
+++ b/retry
@@ -3,21 +3,22 @@
 usage() {
     echo "usage: $0 [options] [cmd...]
 options:
-    -h,--help               Show this help
-    -r,--retries=RETRIES    How many retries to do on command failure after the
-                            initial try. Defaults to 3.
-    -s,--sleep=SLEEP        How many seconds to sleep between retries. Defaults
-                            to 3 seconds.
-    -e,--exponential        Enable simple binary exponential back-off
-                            algorithm. Disabled by default.
+    -h,--help                   Show this help
+    -r,--retries=RETRIES        How many retries to do on command failure after
+                                the initial try. Defaults to 3.
+    -s,--sleep=SLEEP            How many seconds to sleep between retries.
+                                Defaults to 3 seconds.
+    -e,--exponential[=FACTOR]   Enable simple exponential back-off algorithm.
+                                Disabled by default, factor defaults to 2
+                                (binary exponential back-off).
     "
     exit "$1"
 }
 
 # parse arguments
 opts=$(getopt \
-    --options h,r:,s:,e \
-    --longoptions help,retries:,sleep:,exponential \
+    --options h,r:,s:,e:: \
+    --longoptions help,retries:,sleep:,exponential:: \
     --name "$(basename "$0")" -- "$@") || usage 1
 eval set -- "$opts"
 while [ $# -gt 0 ]; do
@@ -25,7 +26,7 @@ while [ $# -gt 0 ]; do
     -h | --help        ) usage 0; shift ;;
     -r | --retries     ) retries=$2; shift 2 ;;
     -s | --sleep       ) sleep=$2; shift 2 ;;
-    -e | --exponential ) exponential=2; shift ;;
+    -e | --exponential ) exponential=${2:-2}; shift 2 ;;
     --                 ) shift; break ;;
     *                  ) break ;;
   esac

--- a/retry
+++ b/retry
@@ -8,23 +8,26 @@ options:
                             initial try. Defaults to 3.
     -s,--sleep=SLEEP        How many seconds to sleep between retries. Defaults
                             to 3 seconds.
+    -e,--exponential        Enable simple binary exponential back-off
+                            algorithm. Disabled by default.
     "
     exit "$1"
 }
 
 # parse arguments
 opts=$(getopt \
-    --options h,r:,s: \
-    --longoptions help,retries:,sleep: \
+    --options h,r:,s:,e \
+    --longoptions help,retries:,sleep:,exponential \
     --name "$(basename "$0")" -- "$@") || usage 1
 eval set -- "$opts"
 while [ $# -gt 0 ]; do
   case "$1" in
-    -h | --help    ) usage 0; shift   ;;
-    -r | --retries ) retries=$2; shift 2 ;;
-    -s | --sleep   ) sleep=$2; shift 2 ;;
-    --             ) shift; break ;;
-    *              ) break ;;
+    -h | --help        ) usage 0; shift ;;
+    -r | --retries     ) retries=$2; shift 2 ;;
+    -s | --sleep       ) sleep=$2; shift 2 ;;
+    -e | --exponential ) exponential=2; shift ;;
+    --                 ) shift; break ;;
+    *                  ) break ;;
   esac
 done
 
@@ -36,5 +39,6 @@ until "$@"; do
     echo "Retrying up to $retries more times after sleeping ${sleep}s …" >&2
     retries=$((retries-1))
     sleep "$sleep"
+    [ -n "$exponential" ] && sleep=$((sleep*exponential))
 done
 [ $retries -gt 0 ]

--- a/test/01-retry.t
+++ b/test/01-retry.t
@@ -17,6 +17,9 @@ plan tests 12
 
 PATH=$dir/..:$PATH
 
+sleep() { :;}
+export -f sleep
+
 ok "$(retry)" 'retry without parameter is ok'
 like "$(retry --help)" usage: 'retry help is shown'
 ok $? 'calling help returns success'
@@ -25,11 +28,11 @@ is $rc 1 'calling with unknown option returns failure'
 like "$out" 'unrecognized option.*usage:' 'retry help is shown for unknown option'
 ok "$(retry true)" 'successful command returns success'
 is "$(retry true)" '' 'successful command does not show any output by default'
-set +e; out=$(retry -s 0 false 2>&1); rc=$?; set -e
+set +e; out=$(retry false 2>&1); rc=$?; set -e
 like "$out" 'Retrying up to 3 more.*Retrying up to 1' 'failing command retries'
 is $rc 1 'failing command returns no success'
 set +e; out=$(retry -s 1 -e -r 2 false 2>&1); rc=$?; set -e
 like "$out" 'sleeping 1s.*sleeping 2s' 'sleep amount doubles'
 is $rc 1 'failing command returns no success'
-set +e; out=$(retry -s 0 -r 1 -- sh -c 'echo -n .; false' 2>/dev/null); set -e
+set +e; out=$(retry -r 1 -- sh -c 'echo -n .; false' 2>/dev/null); set -e
 is "$out" '..' 'specified number of tries (1+retries)'

--- a/test/01-retry.t
+++ b/test/01-retry.t
@@ -13,7 +13,7 @@ PATH=$BASHLIB$PATH
 
 source bash+ :std
 use Test::More
-plan tests 10
+plan tests 12
 
 PATH=$dir/..:$PATH
 
@@ -27,6 +27,9 @@ ok "$(retry true)" 'successful command returns success'
 is "$(retry true)" '' 'successful command does not show any output by default'
 set +e; out=$(retry -s 0 false 2>&1); rc=$?; set -e
 like "$out" 'Retrying up to 3 more.*Retrying up to 1' 'failing command retries'
+is $rc 1 'failing command returns no success'
+set +e; out=$(retry -s 1 -e -r 2 false 2>&1); rc=$?; set -e
+like "$out" 'sleeping 1s.*sleeping 2s' 'sleep amount doubles'
 is $rc 1 'failing command returns no success'
 set +e; out=$(retry -s 0 -r 1 -- sh -c 'echo -n .; false' 2>/dev/null); set -e
 is "$out" '..' 'specified number of tries (1+retries)'


### PR DESCRIPTION
Add option to enable back-off algorithm which will double the sleep amount between each retry. I can drop the commit with tests if desired (as the length of the test is now significantly larger).