### PR TITLE
Add check for return code of retried command

### DIFF
--- a/retry
+++ b/retry
@@ -20,7 +20,9 @@ opts=$(getopt \
     --options h,r:,s:,e:: \
     --longoptions help,retries:,sleep:,exponential:: \
     --name "$(basename "$0")" -- "$@") || usage 1
+
 eval set -- "$opts"
+
 while [ $# -gt 0 ]; do
   case "$1" in
     -h | --help        ) usage 0; shift ;;
@@ -35,11 +37,14 @@ done
 retries="${retries:-3}"
 sleep="${sleep:-3}"
 
+ret=0
 until "$@"; do
+    ret=$?
     [ "$retries" -gt 0 ] || break
     echo "Retrying up to $retries more times after sleeping ${sleep}s …" >&2
     retries=$((retries-1))
     sleep "$sleep"
     [ -n "$exponential" ] && sleep=$((sleep*exponential))
 done
-[ $retries -gt 0 ]
+
+[ $retries -gt 0 ] || [ $ret -eq 0 ]

--- a/test/01-retry.t
+++ b/test/01-retry.t
@@ -13,7 +13,7 @@ PATH=$BASHLIB$PATH
 
 source bash+ :std
 use Test::More
-plan tests 12
+plan tests 14
 
 PATH=$dir/..:$PATH
 
@@ -36,3 +36,7 @@ like "$out" 'sleeping 1s.*sleeping 2s' 'sleep amount doubles'
 is $rc 1 'failing command returns no success'
 set +e; out=$(retry -r 1 -- sh -c 'echo -n .; false' 2>/dev/null); set -e
 is "$out" '..' 'specified number of tries (1+retries)'
+set +e; out=$(retry -r 0 false 2>&1); rc=$?; set -e
+is $rc 1 'failing command without retry returns no success'
+set +e; out=$(retry -r 0 true 2>&1); rc=$?; set -e
+is $rc 0 'passing command without retry returns no error'


### PR DESCRIPTION
This fixes poo#138491

When command failed with retries eq "0" retry script always return 0 as success which can be false positive

So this change adds check for return code if $retries -eq 0