### PR TITLE
Stop mixing option and non-option parameters

### DIFF
--- a/retry
+++ b/retry
@@ -17,7 +17,7 @@ options:
 
 # parse arguments
 opts=$(getopt \
-    --options h,r:,s:,e:: \
+    --options +h,r:,s:,e:: \
     --longoptions help,retries:,sleep:,exponential:: \
     --name "$(basename "$0")" -- "$@") || usage 1
 


### PR DESCRIPTION
Assume all options after first non-option arguments are options for the main command. With this, usages like `retry zypper -h` will interpret options correctly as `retry -- zypper -h`