### PR TITLE
Avoid exit on any non-zero return

### DIFF
--- a/count-fail-ratio
+++ b/count-fail-ratio
@@ -2,6 +2,13 @@
 # shellcheck disable=SC2048
 [ "$1" = "-h" ] || [ "$1" = "--help" ] && echo "Run an arbitrary command multiple times and count failures and fail ratio" && exit
 
+run_once() {
+    "$@" || {
+      fails=$((fails+1))
+      return 0
+    }
+}
+
 fails="${fails:-0}"
 runs="${runs:-"20"}"
 start="${start:-1}"
@@ -11,7 +18,7 @@ declare -a times=()
 for ((i=start; i <= runs; i++)); do
     echo "## Run $i"
     if [ "$timing" = 1 ]; then t_run_start=$(date +%s%N); fi
-    "$@" || fails=$((fails+1))
+    run_once "$@"
     if [ "$timing" = 1 ]; then
         t_run_end=$(date +%s%N)
         runtime=$(( (t_run_end - t_run_start) / 1000000 ))


### PR DESCRIPTION
https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html#index-set
> The shell does not exit if the command that fails is part of the command list immediately following a while or until keyword, part of the test in an if statement, part of any command executed in a && or || list except the command following the final && or ||, any command in a pipeline but the last, or if the command’s return status is being inverted with !.